### PR TITLE
fix: disable vercel image optimization to save resources

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,7 @@ const nextConfig = {
     },
   },
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Summary
- Set `images.unoptimized` to `true` in Next.js config so `next/image` serves original sources instead of Vercel Image Optimization to save resources.